### PR TITLE
Fixes boolean validations and the chronometer feature

### DIFF
--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: Notify Mobile App Devices
-  description: >-
+  description: |-
     **Struggling to make use of the notification options of the [Home Assistant Companion App](https://companion.home-assistant.io/) on your mobile device?**
     **Then this script can help you in the right direction.**
     ***
@@ -1052,7 +1052,7 @@ sequence:
               {%- set ns.data=ns.data+[("chronometer",true)] -%}
               {%- endif -%}
 
-              {%- set ns.data=ns.data+[("when",when)] -%}
+              {%- set ns.data=ns.data+[("when",(when|int|string()))] -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/critical-notifications/#ios -#}
               {%- if manufacturer=="Apple" and data_critical is defined -%}

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -151,7 +151,7 @@ fields:
         integration: mobile_app
   notify_home_or_away:
     name: Notify those that are Home or Away?
-    required: false
+    required: true
     example: Both
     selector:
       select:
@@ -310,12 +310,19 @@ fields:
         step: 10
         mode: slider
   data_chronometer:
-    name: Android Only - Notifications with a count up/down timer (Optional)
+    name: Android Only - The timestamp of the notification (Optional)
     example: '"{{now()+timedelta(minutes=1)}}"'
-    description: Show a count up/down timer. Notification will not disappear when the timer reaches 0. Instead, it will continue decrementing into negative values.
+    description: Shows a timestamp. Notification will not disappear when the timer reaches 0. Instead, it will continue decrementing into negative values.
     required: false
     selector:
       datetime: null
+  data_chronometer_enable:
+    name: Android Only - (when combined with data_chronometer) Enable the Notifications timer with a count up/down timer (Optional)
+    description: Show a count up/down timer. Notification will not disappear when the timer reaches 0. Instead, it will continue decrementing into negative values.
+    example: true
+    required: false
+    selector:
+      boolean: null
   data_notification_color:
     name: Android Only - Color of the notification icon (Optional)
     required: false
@@ -933,312 +940,316 @@ sequence:
             servicedata: >-
         - variables:
             servicedata: >-
-              {# object which stores all options #}
-              {% set ns=namespace(servicedata=[],data=[],push=[],sound=[],actions=[],hex_color="#") %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic/#notification-channels #}
-              {% if data_channel is defined %}
-              {% set ns.data=ns.data+[("channel",data_channel)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic/#text-to-speech-notifications #}
-              {% if notify_title is defined and (notify_message|upper)=="TTS" %}
-              {% set ns.data=ns.data+[("tts_text",notify_title)] %}
-              {% endif %}
-              {# By default Text To Speech notifications use the music stream so they will bypass the ringer mode on the device as long as the device's volume is not set to 0. You have the option of using media_stream: alarm_stream to have your notification spoken regardless of music volume. #}
-              {% if data_device_ring is defined and (data_device_ring|lower) in ["on","max"] %}
-              {% set data_importance="high" %}
-              {# https://companion.home-assistant.io/docs/notifications/critical-notifications#android-text-to-speech-alarm-stream #}
-              {% if (data_device_ring|lower)=="on" and (notify_message|upper)=="TTS" %}
-              {% set ns.data=ns.data+[("media_stream","alarm_stream")] %}
-              {% endif %}
-              {% if (data_device_ring|lower)=="on" and (notify_message|upper)!="TTS" %}
-              {% set ns.data=ns.data+[("channel","alarm_stream")] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/critical-notifications#android-text-to-speech-alarm-stream-max-volume #}
-              {% if (data_device_ring|lower)=="max" and (notify_message|upper)=="TTS" %}
-              {% set ns.data=ns.data+[("media_stream","alarm_stream_max")] %}
-              {% set data_importance="max" %}
-              {% endif %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-icon #}
-              {# making sure that the value contains mdi: , otherwise skipping #}
-              {% if manufacturer!="Apple" and data_notification_icon is defined and ([data_notification_icon]|select("search","mdi:")|list)|count==1 %}
-              {% set ns.data=ns.data+[("notification_icon",data_notification_icon)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#grouping #}
-              {% if data_group is defined %}
-              {% set ns.data=ns.data+[("group",data_group)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#replacing #}
-              {% if data_tag is defined %}
-              {% set ns.data=ns.data+[("tag",data_tag)] %}
-              {% endif %}
-              {% if manufacturer!="Apple" and data_persistent is defined %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#persistent-notification #}
-              {# making sure that an boolean is specified, otherwise skipping #}
-              {% if data_persistent is boolean %}
-              {% set data_persistent=bool(data_persistent) %}
-              {% set ns.data=ns.data+[("persistent",data_persistent)] %}
-              {% endif %}
-              {# Clearing persistant notifications require you to define a tag (value does not matter). If the user forgets to set the tag then the default value will be: "persistent" #}
-              {% if bool(data_persistent)==true and data_tag is not defined%}
-              {% set ns.data=ns.data+[("tag","persistent")] %}
-              {% endif %}
-              {% endif %}
-              {% if data_tag is defined and data_tag=="persistent" and (notify_message|lower)!="clear_notification" %}
-              {% set ns.data=ns.data+[("persistent",true)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic/#subtitle--subject #}
-              {% if data_subtitle is defined%}
-              {% if manufacturer=="Apple" %}
-              {# Apple uses "subtitle" #}
-              {% set ns.data=ns.data+[("subtitle",data_subtitle)] %}
-              {% endif %}
-              {% if manufacturer!="Apple" %}
-              {# Android uses "subject" #}
-              {% set ns.data=ns.data+[("subject",data_subtitle)] %}
-              {% endif %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic/#notification-color #}
-              {% if manufacturer!="Apple" and data_notification_color is defined %}
-              {# The rgb color object selector spits it out as list with r,g and b [255,0,0]. This conflicts with the notification-color documentation, which requires HEX values. It has now been fixed. Thanks to https://github.com/velijv/home-assistant-color-helpers#rgb-to-hex #}
-              {# Converting the list of [r,g,b] to hex #}
-              {% for color in data_notification_color %}
-              {% set ns.hex_color=ns.hex_color+('%02x'%color) %}
-              {% endfor %}
-              {% set ns.data=ns.data+[("color",ns.hex_color)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-sensitivity--lock-screen-visibility #}
-              {% if manufacturer!="Apple" and data_visibility is defined %}
-              {# making sure that data_visibility is either one of the three, otherwise skipping #}
-              {% if data_visibility|lower in ["public","private","secret"] %}
-              {% set ns.data=ns.data+[("visibility",data_visibility|lower)] %}
-              {% endif %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#opening-a-url #}
-              {% if manufacturer!="Apple" %}
-              {% if data_clickaction is defined and states(data_clickaction)!="unknown" %}
-              {% set ns.data=ns.data+[("clickAction","entityId:"~data_clickaction)] %}
-              {% endif %}
-              {% if data_clickaction_url is defined %}
-              {% set ns.data=ns.data+[("clickAction",data_clickaction_url)] %}
-              {% endif %}
-              {% endif %}
-              {% if manufacturer=="Apple" and data_clickaction_url is defined and not (
-                data_clickaction_url is search("app://",ignorecase=False) or 
-                data_clickaction_url is search("intent://",ignorecase=False) or 
-                data_clickaction_url is search("deep-link://",ignorecase=False) or 
-                data_clickaction_url is search("entityId:",ignorecase=False) or 
-                data_clickaction_url is search("settings://",ignorecase=False)
-              ) %}
-              {% set ns.data=ns.data+[("url",data_clickaction_url)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#chronometer-notifications #}
-              {# Sometime the data_chronometer is set to data_chronometer="undefined 00:00:00". this will fix this issue #}
-              {% if manufacturer!="Apple" and data_chronometer is defined and data_chronometer!="undefined 00:00:00" and (as_timestamp(data_chronometer,default=0)|float()>0 or strptime(data_chronometer, 'undefined %H:%M:%S',default=0)!=0) %}
-              {% if strptime(data_chronometer, 'undefined %H:%M:%S',default=0)!=0 %}
-              {% set when=as_timestamp(strptime(data_chronometer, 'undefined %H:%M:%S').replace(year=now().year,month=now().month,day=now().day))|float %}
-              {% else %}
-              {% set when=as_timestamp(data_chronometer,default=as_timestamp(now()))|float()%}
-              {% endif %}
-              {% set ns.data=ns.data+[("chronometer",true)] %}
-              {% set ns.data=ns.data+[("when",when)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/critical-notifications/#ios #}
-              {% if manufacturer=="Apple" and data_critical is defined %}
-              {% if bool(data_critical)==true %}
-              {% set ns.sound=ns.sound+[("name","default")] %}
-              {% set ns.sound=ns.sound+[("critical",1)] %}
-              {% if data_ios_sound_volumelevel is defined and is_number(data_ios_sound_volumelevel) %}
-              {% set ns.sound=ns.sound+[("volume",(data_ios_sound_volumelevel|float))] %}
-              {% else %}
-              {% set ns.sound=ns.sound+[("volume",1)] %}
-              {% endif %}
-              {% endif %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-channel-importance #}
-              {% if data_importance is defined and data_importance|lower in ["max","high","default","low","min"] %}
-              {# Priority (Android 7.1 and lower) #}
-              {% set ns.data=ns.data+[("priority",(data_importance|lower))] %}
-              {# Importance (Android 8.0 and higher) #} 
-              {% if data_importance=="max" %}
-              {% set data_importance="high" %}
-              {% endif %}
-              {% set ns.data=ns.data+[("importance",(data_importance|lower))] %}
-              {% if data_importance=="high" %}
-              {% set ns.data=ns.data+[("ttl",(0|int))] %}
-              {% endif %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-timeout #}
-              {% if manufacturer!="Apple" and data_timeout is defined and data_timeout is is_number%}
-              {% set ns.data=ns.data+[("timeout",(data_timeout|int))] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#sticky-notification #}
-              {% if data_sticky is defined and data_sticky|lower in [true,false,"true","false",0,1,"0","1","yes","no","enable","disable"] %}
-              {% set ns.data=ns.data+[("sticky",bool(data_sticky))] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notification-attachments #}
-              {# The data_camera can accept various options, but the results are different for Android or iOS #}
-              {# Examples: #}
-              {#  * data_camera: camera.name #}
-              {#  * data_camera: /api/nest/event_media/{{ trigger.event.data.device_id }}/{{ trigger.event.data.nest_event_id }}/thumbnail #}
-              {#  * data_camera: /api/nest/event_media/{{ trigger.event.data.device_id }}/{{ trigger.event.data.nest_event_id }} #}
-              {#  * data_camera: /media/local/video.mp4 #}
-              {#  * data_camera: https://example.com/video.mp4 #}
-              {#  * data_camera: /media/local/photo.jpg #}
-              {#  * data_camera: https://example.com/image.jpg #}
-              {#  * data_camera: /media/local/audio.mp3 #}
-              {#  * data_camera: https://example.com/audio.mp3 #}
-              {% if data_camera is defined %}
-                {#  * data_camera: camera.name #}
-                {% if states(data_camera)!="unknown" %}
-                  {% if manufacturer!="Apple" %}
-                  {# https://companion.home-assistant.io/docs/notifications/notification-attachments#automatic-snapshots #}
-                  {% set ns.data=ns.data+[("image","/api/camera_proxy/"~data_camera)] %}
-                  {% else %}
-                  {# https://companion.home-assistant.io/docs/notifications/dynamic-content#camera-stream #}
-                  {% set ns.data=ns.data+[("entity_id",data_camera)] %}
-                  {% endif %}
-                {% endif %}
-                {# https://www.home-assistant.io/integrations/nest/#media-attachments #}
-                {# * image is data_camera: /api/nest/event_media/{{ trigger.event.data.device_id }}/{{ trigger.event.data.nest_event_id }}/thumbnail #}
-                {# * video is data_camera: /api/nest/event_media/{{ trigger.event.data.device_id }}/{{ trigger.event.data.nest_event_id }} #}
-                {% if states(data_camera) == "unknown" and data_camera is search("/api/nest/event_media/",ignorecase=False) %}
-                  {% if states(data_camera) == "unknown" and data_camera is search("/thumbnail",ignorecase=False) %}
-                    {% set ns.data=ns.data+[("image",data_camera)] %}
-                    {% set ns.data=ns.data+[("video",(data_camera|replace("/thumbnail","")))] %}
-                  {% endif %}
-                  {% if states(data_camera) == "unknown" and (data_camera|regex_match('^((\/)(\w+)){5}$', ignorecase=False)) %}
-                    {% set ns.data=ns.data+[("video",data_camera)] %}
-                  {% endif %}
-                {% endif %}
-                {# https://companion.home-assistant.io/docs/notifications/notification-attachments#downloading #}
-                {# check if data_camera is an allowed format from the media_source or www folder #}
-                {% if data_camera is search("/media/local/",ignorecase=true) or data_camera is search("/local/",ignorecase=true) or data_camera is search("https://",ignorecase=true) or data_camera is search("http://",ignorecase=true) %}
-                  
-                  {# check if it is an allowed format for the image type: https://companion.home-assistant.io/docs/notifications/notification-attachments#supported-media-types #}
-                  {% if data_camera is search(".jpg",ignorecase=true) or 
-                        data_camera is search(".gif",ignorecase=true) or 
-                        data_camera is search(".png",ignorecase=true) %}
-                    {% set ns.data=ns.data+[("image",data_camera)] %}
-                  {% endif %}
-                  {# check if it is an allowed format for the video type: https://companion.home-assistant.io/docs/notifications/notification-attachments#supported-media-types #}
-                  {% if data_camera is search(".mp4",ignorecase=true) or 
-                        data_camera is search(".mpeg",ignorecase=true) or 
-                        data_camera is search(".avi",ignorecase=true) %}
-                    {% set ns.data=ns.data+[("video",data_camera)] %}
-                  {% endif %}
-                  
-                  {# audio is only supported by iOS devices #} 
-                  {# check if it is an allowed format for the video audio: https://companion.home-assistant.io/docs/notifications/notification-attachments#supported-media-types #}
-                  {% if manufacturer=="Apple" and (
-                        data_camera is search(".mp3",ignorecase=true) or 
-                        data_camera is search(".aiff",ignorecase=true) or 
-                        data_camera is search(".wav",ignorecase=true) 
-                  ) %}
-                    {% set ns.data=ns.data+[("audio",data_camera)] %}
-                  {% endif %}
-                {% endif %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notification-sounds #}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#sounds #}
-              {% if manufacturer=="Apple" and data_ios_sound is defined %}
-              {% set ns.sound=ns.sound+[("name",data_ios_sound)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/critical-notifications#ios #}
-              {% if manufacturer=="Apple" and data_critical is defined and data_critical==True %}
-              {% if data_ios_sound_volumelevel is not defined %}
-              {# have an default value incase the data_ios_sound_volumelevel is not defined #}
-              {% set data_ios_sound_volumelevel=1 %}
-              {% endif %}
-              {% set ns.sound=ns.sound+[("volume",(data_ios_sound_volumelevel|float))] %}
-              {% set ns.sound=ns.sound+[("critical",1)] %}
-              {% endif %}
-              {% if manufacturer=="Apple" and data_ios_sound_volumelevel is defined and data_ios_sound_volumelevel is is_number %}
-              {% set ns.sound=ns.sound+[("volume",(data_ios_sound_volumelevel|float))] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#badge #}
-              {% if manufacturer=="Apple" and data_ios_badge is defined and data_ios_badge is is_number%}
-              {% set ns.push=ns.push+[("badge",(data_ios_badge|int))] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#interruption-level #}
-              {% if manufacturer=="Apple" and data_ios_interruption_level is defined %}
-              {% if data_ios_interruption_level|lower is not in ["passive","active","time-sensitive","critical"] %}
-              {# have an default value incase the data_ios_interruption_level is not correct #}
-              {% set data_ios_interruption_level="active" %}
-              {% endif %}
-              {% set ns.push=ns.push+[("interruption-level",(data_ios_interruption_level|lower))] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/notifications-basic#presentation-options #}
-              {% if manufacturer=="Apple" and data_ios_presentation_options is defined %}
-              {# check if the value(s) is allowed. It can contain one or more values #}
-              {% set allowed_values=["alert","badge","sound"] %}
-              {% set list=namespace(allowed_value=[]) %}
-              {% if (data_ios_presentation_options|lower) is in allowed_values %}
-              {% set list.allowed_value=list.allowed_value+[(data_ios_presentation_options|lower)] %}
-              {% else %}
-              {% for value in data_ios_presentation_options %}
-              {% if (value|lower) is in allowed_values %}
-              {% set list.allowed_value=list.allowed_value+[(value|lower)] %}
-              {% endif %}
-              {% endfor %}
-              {% endif %}
-              {% set ns.data=ns.data+[("presentation_options",list.allowed_value)] %}
-              {% endif %}
-              {# https://companion.home-assistant.io/docs/notifications/actionable-notifications #}
-              {# Android and iOS accept different type of actions, and this will filter those that are allowed per OS (according to the docs) #}
-              {% if data_actions is defined%}
-              {% for action in data_actions %}
-              {# https://companion.home-assistant.io/docs/notifications/actionable-notifications#uri-values #}
-              {# exclude certain uri values if the device is iOS #}
-              {% if manufacturer=="Apple" and action['uri'] is defined and  (
-                action['uri'] is search("app://",ignorecase=False) or 
-                action['uri'] is search("intent://",ignorecase=False) or 
-                action['uri'] is search("deep-link://",ignorecase=False) or 
-                action['uri'] is search("entityId:",ignorecase=False) or 
-                action['uri'] is search("settings://",ignorecase=False)
-              ) %}
-              {%else%}
-              {%if manufacturer!="Apple" and (
-                action['action']=="CALL" or 
-                action['action']=="OPEN"
-                ) and (
-                action['uri'] is search("https://",ignorecase=False) or 
-                action['uri'] is search("tel:",ignorecase=False)
-                ) %}
-              {%else%}
-              {%set ns.actions=ns.actions+[(action)] %}
-              {% endif %}
-              {% endif %}
-              {%endfor%}
-              {% if ns.actions|count>=1%}
-              {% set ns.data=ns.data+[("actions",ns.actions)] %}
-              {% endif %}
-              {% endif %}
-              {# Finally add the sound to the push object as an DICT #}
-              {% if (ns.sound|count)>=1 %}
-              {% set ns.push=ns.push+[("sound",dict.from_keys(ns.sound))] %}
-              {% endif %}
-              {# Finally add the push to the data object as an DICT #}
-              {% if (ns.push|count)>=1 %}
-              {% set ns.data=ns.data+[("push",dict.from_keys(ns.push))] %}
-              {% endif %}
-              {# message and title are basic entries, but title is optional #}
-              {% if notify_title is defined and (notify_message|upper)!="TTS"%}
-              {% set ns.servicedata=ns.servicedata+[("title",notify_title)] %}
-              {% endif %}
-              {# make sure that the message: <value> has an default value or is formatted correctly #}
-              {% if notify_message is not defined %}
-              {% set notify_message="Hello World" %}
-              {% endif %}
-              {% if (notify_message|upper)=="TTS" %}
-              {% set notify_message="TTS" %}
-              {% endif %}
-              {% if (notify_message|lower)=="clear_notification" %}
-              {% set notify_message=(notify_message|lower) %}
-              {% endif %}
-              {% set ns.servicedata=ns.servicedata+[("message",notify_message)] %}
-              {% set ns.servicedata=ns.servicedata+[("data",dict.from_keys(ns.data))] %}
-              {# Finally show the results as an DICT #}
+              {# object which stores all options -#}
+              {%- set ns=namespace(servicedata=[],data=[],push=[],sound=[],actions=[],hex_color="#") -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#notification-channels -#}
+              {%- if data_channel is defined -%}
+              {%- set ns.data=ns.data+[("channel",data_channel)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#text-to-speech-notifications -#}
+              {%- if notify_title is defined and (notify_message|upper)=="TTS" -%}
+              {%- set ns.data=ns.data+[("tts_text",notify_title)] -%}
+              {%- endif -%}
+              {#- By default Text To Speech notifications use the music stream so they will bypass the ringer mode on the device as long as the device's volume is not set to 0. You have the option of using media_stream: alarm_stream to have your notification spoken regardless of music volume. -#}
+              {%- if data_device_ring is defined and (data_device_ring|lower) in ["on","max"] -%}
+              {%- set data_importance="high" -%}
+              {#- https://companion.home-assistant.io/docs/notifications/critical-notifications#android-text-to-speech-alarm-stream -#}
+              {%- if (data_device_ring|lower)=="on" and (notify_message|upper)=="TTS" -%}
+              {%- set ns.data=ns.data+[("media_stream","alarm_stream")] -%}
+              {%- endif -%}
+              {%- if (data_device_ring|lower)=="on" and (notify_message|upper)!="TTS" -%}
+              {%- set ns.data=ns.data+[("channel","alarm_stream")] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/critical-notifications#android-text-to-speech-alarm-stream-max-volume -#}
+              {%- if (data_device_ring|lower)=="max" and (notify_message|upper)=="TTS" -%}
+              {%- set ns.data=ns.data+[("media_stream","alarm_stream_max")] -%}
+              {%- set data_importance="max" -%}
+              {%- endif -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-icon -#}
+              {#- making sure that the value contains mdi: , otherwise skipping -#}
+              {%- if manufacturer!="Apple" and data_notification_icon is defined and ([data_notification_icon]|select("search","mdi:")|list)|count==1 -%}
+              {%- set ns.data=ns.data+[("notification_icon",data_notification_icon)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#grouping -#}
+              {%- if data_group is defined -%}
+              {%- set ns.data=ns.data+[("group",data_group)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#replacing -#}
+              {%- if data_tag is defined -%}
+              {%- set ns.data=ns.data+[("tag",data_tag)] -%}
+              {%- endif -%}
+              {%- if manufacturer!="Apple" and data_persistent is defined -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#persistent-notification -#}
+              {#- making sure that an boolean is specified, otherwise skipping -#}
+              {%- if data_persistent is boolean -%}
+              {%- set data_persistent=bool(data_persistent,false) -%}
+              {%- set ns.data=ns.data+[("persistent",data_persistent)] -%}
+              {%- endif -%}
+              {#- Clearing persistant notifications require you to define a tag (value does not matter). If the user forgets to set the tag then the default value will be: "persistent" -#}
+              {%- if bool(data_persistent,false)==true and data_tag is not defined -%}
+              {%- set ns.data=ns.data+[("tag","persistent")] -%}
+              {%- endif -%}
+              {%- endif -%}
+              {%- if data_tag is defined and data_tag=="persistent" and (notify_message|lower)!="clear_notification" -%}
+              {%- set ns.data=ns.data+[("persistent",true)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#subtitle--subject -#}
+              {%- if data_subtitle is defined -%}
+              {%- if manufacturer=="Apple" -%}
+              {#- Apple uses "subtitle" -#}
+              {%- set ns.data=ns.data+[("subtitle",data_subtitle)] -%}
+              {%- endif -%}
+              {%- if manufacturer!="Apple" -%}
+              {#- Android uses "subject" -#}
+              {%- set ns.data=ns.data+[("subject",data_subtitle)] -%}
+              {%- endif -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#notification-color -#}
+              {%- if manufacturer!="Apple" and data_notification_color is defined -%}
+              {#- The rgb color object selector spits it out as list with r,g and b [255,0,0]. This conflicts with the notification-color documentation, which requires HEX values. It has now been fixed. Thanks to https://github.com/velijv/home-assistant-color-helpers#rgb-to-hex -#}
+              {#- Converting the list of [r,g,b] to hex -#}
+              {%- for color in data_notification_color -%}
+              {%- set ns.hex_color=ns.hex_color+('%02x'%color) -%}
+              {%- endfor -%}
+              {%- set ns.data=ns.data+[("color",ns.hex_color)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-sensitivity--lock-screen-visibility -#}
+              {%- if manufacturer!="Apple" and data_visibility is defined -%}
+              {#- making sure that data_visibility is either one of the three, otherwise skipping -#}
+              {%- if data_visibility|lower in ["public","private","secret"] -%}
+              {%- set ns.data=ns.data+[("visibility",data_visibility|lower)] -%}
+              {%- endif -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#opening-a-url -#}
+              {%- if manufacturer!="Apple" -%}
+              {%- if data_clickaction is defined and states(data_clickaction)!="unknown" -%}
+              {%- set ns.data=ns.data+[("clickAction","entityId:"~data_clickaction)] -%}
+              {%- endif -%}
+              {%- if data_clickaction_url is defined -%}
+              {%- set ns.data=ns.data+[("clickAction",data_clickaction_url)] -%}
+              {%- endif -%}
+              {%- endif -%}
+              {%- if manufacturer=="Apple" and data_clickaction_url is defined and not (
+              data_clickaction_url is search("app://",ignorecase=False) or 
+              data_clickaction_url is search("intent://",ignorecase=False) or 
+              data_clickaction_url is search("deep-link://",ignorecase=False) or 
+              data_clickaction_url is search("entityId:",ignorecase=False) or 
+              data_clickaction_url is search("settings://",ignorecase=False)
+              ) -%}
+              {%- set ns.data=ns.data+[("url",data_clickaction_url)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#chronometer-notifications -#}
+              {#- Sometime the data_chronometer is set to data_chronometer="undefined 00:00:00". this will fix this issue -#}
+              {%- if manufacturer!="Apple" and data_chronometer is defined and data_chronometer!="undefined 00:00:00" and (as_timestamp(data_chronometer,default=0)|float()>0 or strptime(data_chronometer, 'undefined %H:%M:%S',default=0)!=0) -%}
+              {%- if strptime(data_chronometer, 'undefined %H:%M:%S',default=0)!=0 -%}
+              {%- set when=as_timestamp(strptime(data_chronometer, 'undefined %H:%M:%S').replace(year=now().year,month=now().month,day=now().day))|float -%}
+              {%- else -%}
+              {%- set when=as_timestamp(data_chronometer,default=as_timestamp(now()))|float() -%}
+              {%- endif -%}
+
+              {%- if data_chronometer_enable is defined and bool(data_chronometer_enable,false)==true -%}
+              {%- set ns.data=ns.data+[("chronometer",true)] -%}
+              {%- endif -%}
+
+              {%- set ns.data=ns.data+[("when",when)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/critical-notifications/#ios -#}
+              {%- if manufacturer=="Apple" and data_critical is defined -%}
+              {%- if bool(data_critical,false)==true -%}
+              {%- set ns.sound=ns.sound+[("name","default")] -%}
+              {%- set ns.sound=ns.sound+[("critical",1)] -%}
+              {%- if data_ios_sound_volumelevel is defined and is_number(data_ios_sound_volumelevel) -%}
+              {%- set ns.sound=ns.sound+[("volume",(data_ios_sound_volumelevel|float))] -%}
+              {%- else -%}
+              {%- set ns.sound=ns.sound+[("volume",1)] -%}
+              {%- endif -%}
+              {%- endif -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-channel-importance -#}
+              {%- if data_importance is defined and data_importance|lower in ["max","high","default","low","min"] -%}
+              {#- Priority (Android 7.1 and lower) -#}
+              {%- set ns.data=ns.data+[("priority",(data_importance|lower))] -%}
+              {#- Importance (Android 8.0 and higher) -#} 
+              {%- if data_importance=="max" -%}
+              {%- set data_importance="high" -%}
+              {%- endif -%}
+              {%- set ns.data=ns.data+[("importance",(data_importance|lower))] -%}
+              {%- if data_importance=="high" -%}
+              {%- set ns.data=ns.data+[("ttl",(0|int))] -%}
+              {%- endif -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-timeout -#}
+              {%- if manufacturer!="Apple" and data_timeout is defined and data_timeout is is_number -%}
+              {%- set ns.data=ns.data+[("timeout",(data_timeout|int))] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#sticky-notification -#}
+              {%- if data_sticky is defined and data_sticky|lower in [true,false,"true","false",0,1,"0","1","yes","no","enable","disable"] -%}
+              {%- set ns.data=ns.data+[("sticky",bool(data_sticky,false))] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notification-attachments -#}
+              {#- The data_camera can accept various options, but the results are different for Android or iOS -#}
+              {#- Examples: -#}
+              {#- * data_camera: camera.name -#}
+              {#- * data_camera: /api/nest/event_media/{{ trigger.event.data.device_id }}/{{ trigger.event.data.nest_event_id }}/thumbnail -#}
+              {#- * data_camera: /api/nest/event_media/{{ trigger.event.data.device_id }}/{{ trigger.event.data.nest_event_id }} -#}
+              {#- * data_camera: /media/local/video.mp4 -#}
+              {#- * data_camera: https://example.com/video.mp4 -#}
+              {#- * data_camera: /media/local/photo.jpg -#}
+              {#- * data_camera: https://example.com/image.jpg -#}
+              {#- * data_camera: /media/local/audio.mp3 -#}
+              {#- * data_camera: https://example.com/audio.mp3 -#}
+              {%- if data_camera is defined -%}
+              {#- * data_camera: camera.name -#}
+              {%- if states(data_camera)!="unknown" -%}
+                {%- if manufacturer!="Apple" -%}
+                {#- https://companion.home-assistant.io/docs/notifications/notification-attachments#automatic-snapshots -#}
+                {%- set ns.data=ns.data+[("image","/api/camera_proxy/"~data_camera)] -%}
+                {%- else -%}
+                {#- https://companion.home-assistant.io/docs/notifications/dynamic-content#camera-stream -#}
+                {%- set ns.data=ns.data+[("entity_id",data_camera)] -%}
+                {%- endif -%}
+              {%- endif -%}
+              {#- https://www.home-assistant.io/integrations/nest/#media-attachments -#}
+              {#- * image is data_camera: /api/nest/event_media/{{ trigger.event.data.device_id }}/{{ trigger.event.data.nest_event_id }}/thumbnail -#}
+              {#- * video is data_camera: /api/nest/event_media/{{ trigger.event.data.device_id }}/{{ trigger.event.data.nest_event_id }} -#}
+              {%- if states(data_camera) == "unknown" and data_camera is search("/api/nest/event_media/",ignorecase=False) -%}
+                {%- if states(data_camera) == "unknown" and data_camera is search("/thumbnail",ignorecase=False) -%}
+                {%- set ns.data=ns.data+[("image",data_camera)] -%}
+                {%- set ns.data=ns.data+[("video",(data_camera|replace("/thumbnail","")))] -%}
+                {%- endif -%}
+                {%- if states(data_camera) == "unknown" and (data_camera|regex_match('^((\/)(\w+)){5}$', ignorecase=False)) -%}
+                {%- set ns.data=ns.data+[("video",data_camera)] -%}
+                {%- endif -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notification-attachments#downloading -#}
+              {#- check if data_camera is an allowed format from the media_source or www folder -#}
+              {%- if data_camera is search("/media/local/",ignorecase=true) or data_camera is search("/local/",ignorecase=true) or data_camera is search("https://",ignorecase=true) or data_camera is search("http://",ignorecase=true) -%}
+                
+                {#- check if it is an allowed format for the image type: https://companion.home-assistant.io/docs/notifications/notification-attachments#supported-media-types -#}
+                {%- if data_camera is search(".jpg",ignorecase=true) or 
+                  data_camera is search(".gif",ignorecase=true) or 
+                  data_camera is search(".png",ignorecase=true) -%}
+                {%- set ns.data=ns.data+[("image",data_camera)] -%}
+                {%- endif -%}
+                {#- check if it is an allowed format for the video type: https://companion.home-assistant.io/docs/notifications/notification-attachments#supported-media-types -#}
+                {%- if data_camera is search(".mp4",ignorecase=true) or 
+                  data_camera is search(".mpeg",ignorecase=true) or 
+                  data_camera is search(".avi",ignorecase=true) -%}
+                {%- set ns.data=ns.data+[("video",data_camera)] -%}
+                {%- endif -%}
+                
+                {#- audio is only supported by iOS devices -#} 
+                {#- check if it is an allowed format for the video audio: https://companion.home-assistant.io/docs/notifications/notification-attachments#supported-media-types -#}
+                {%- if manufacturer=="Apple" and (
+                  data_camera is search(".mp3",ignorecase=true) or 
+                  data_camera is search(".aiff",ignorecase=true) or 
+                  data_camera is search(".wav",ignorecase=true) 
+                ) -%}
+                {%- set ns.data=ns.data+[("audio",data_camera)] -%}
+                {%- endif -%}
+              {%- endif -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notification-sounds -#}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#sounds -#}
+              {%- if manufacturer=="Apple" and data_ios_sound is defined -%}
+              {%- set ns.sound=ns.sound+[("name",data_ios_sound)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/critical-notifications#ios -#}
+              {%- if manufacturer=="Apple" and data_critical is defined and data_critical==True -%}
+              {%- if data_ios_sound_volumelevel is not defined -%}
+              {#- have an default value incase the data_ios_sound_volumelevel is not defined -#}
+              {%- set data_ios_sound_volumelevel=1 -%}
+              {%- endif -%}
+              {%- set ns.sound=ns.sound+[("volume",(data_ios_sound_volumelevel|float))] -%}
+              {%- set ns.sound=ns.sound+[("critical",1)] -%}
+              {%- endif -%}
+              {%- if manufacturer=="Apple" and data_ios_sound_volumelevel is defined and data_ios_sound_volumelevel is is_number -%}
+              {%- set ns.sound=ns.sound+[("volume",(data_ios_sound_volumelevel|float))] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#badge -#}
+              {%- if manufacturer=="Apple" and data_ios_badge is defined and data_ios_badge is is_number -%}
+              {%- set ns.push=ns.push+[("badge",(data_ios_badge|int))] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#interruption-level -#}
+              {%- if manufacturer=="Apple" and data_ios_interruption_level is defined -%}
+              {%- if data_ios_interruption_level|lower is not in ["passive","active","time-sensitive","critical"] -%}
+              {#- have an default value incase the data_ios_interruption_level is not correct -#}
+              {%- set data_ios_interruption_level="active" -%}
+              {%- endif -%}
+              {%- set ns.push=ns.push+[("interruption-level",(data_ios_interruption_level|lower))] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#presentation-options -#}
+              {%- if manufacturer=="Apple" and data_ios_presentation_options is defined -%}
+              {#- check if the value(s) is allowed. It can contain one or more values -#}
+              {%- set allowed_values=["alert","badge","sound"] -%}
+              {%- set list=namespace(allowed_value=[]) -%}
+              {%- if (data_ios_presentation_options|lower) is in allowed_values -%}
+              {%- set list.allowed_value=list.allowed_value+[(data_ios_presentation_options|lower)] -%}
+              {%- else -%}
+              {%- for value in data_ios_presentation_options -%}
+              {%- if (value|lower) is in allowed_values -%}
+              {%- set list.allowed_value=list.allowed_value+[(value|lower)] -%}
+              {%- endif -%}
+              {%- endfor -%}
+              {%- endif -%}
+              {%- set ns.data=ns.data+[("presentation_options",list.allowed_value)] -%}
+              {%- endif -%}
+              {#- https://companion.home-assistant.io/docs/notifications/actionable-notifications -#}
+              {#- Android and iOS accept different type of actions, and this will filter those that are allowed per OS (according to the docs) -#}
+              {%- if data_actions is defined -%}
+              {%- for action in data_actions -%}
+              {#- https://companion.home-assistant.io/docs/notifications/actionable-notifications#uri-values -#}
+              {#- exclude certain uri values if the device is iOS -#}
+              {%- if manufacturer=="Apple" and action['uri'] is defined and (
+              action['uri'] is search("app://",ignorecase=False) or 
+              action['uri'] is search("intent://",ignorecase=False) or 
+              action['uri'] is search("deep-link://",ignorecase=False) or 
+              action['uri'] is search("entityId:",ignorecase=False) or 
+              action['uri'] is search("settings://",ignorecase=False)
+              ) -%}
+              {%- else -%}
+              {%- if manufacturer!="Apple" and (
+              action['action']=="CALL" or 
+              action['action']=="OPEN"
+              ) and (
+              action['uri'] is search("https://",ignorecase=False) or 
+              action['uri'] is search("tel:",ignorecase=False)
+              ) -%}
+              {%- else -%}
+              {%- set ns.actions=ns.actions+[(action)] -%}
+              {%- endif -%}
+              {%- endif -%}
+              {%- endfor%}
+              {%- if ns.actions|count>=1 -%}
+              {%- set ns.data=ns.data+[("actions",ns.actions)] -%}
+              {%- endif -%}
+              {%- endif -%}
+              {#- Finally add the sound to the push object as an DICT -#}
+              {%- if (ns.sound|count)>=1 -%}
+              {%- set ns.push=ns.push+[("sound",dict.from_keys(ns.sound))] -%}
+              {%- endif -%}
+              {#- Finally add the push to the data object as an DICT -#}
+              {%- if (ns.push|count)>=1 -%}
+              {%- set ns.data=ns.data+[("push",dict.from_keys(ns.push))] -%}
+              {%- endif -%}
+              {#- message and title are basic entries, but title is optional -#}
+              {%- if notify_title is defined and (notify_message|upper)!="TTS" -%}
+              {%- set ns.servicedata=ns.servicedata+[("title",notify_title)] -%}
+              {%- endif -%}
+              {#- make sure that the message: <value> has an default value or is formatted correctly -#}
+              {%- if notify_message is not defined -%}
+              {%- set notify_message="Hello World" -%}
+              {%- endif -%}
+              {%- if (notify_message|upper)=="TTS" -%}
+              {%- set notify_message="TTS" -%}
+              {%- endif -%}
+              {%- if (notify_message|lower)=="clear_notification" -%}
+              {%- set notify_message=(notify_message|lower) -%}
+              {%- endif -%}
+              {%- set ns.servicedata=ns.servicedata+[("message",notify_message)] -%}
+              {%- set ns.servicedata=ns.servicedata+[("data",dict.from_keys(ns.data))] -%}
+              {#- Finally show the results as an DICT -#}
               {{dict.from_keys(ns.servicedata)}}
         - service: "{{service}}"
           data: "{{servicedata}}"


### PR DESCRIPTION
Fixed boolean validation
-----------------
When a none boolean value was passed to one of the boolean fields then the code completely failed. 
For example:
```data_sticky: tru``` where ```tru``` should have been ```true``` .

This issue is now resolved by validating the boolean and defining a default value ``` bool(data_sticky,false) ``` this means that if an value ```tru``` was used that the result is ```false``` instead of a complete failure of the code 😵‍💫😫

Fixed chronometer 
------------------
The chronometer option is used for Android devices. This feature was already implemented, it did not work properly. This is now  extensively tested and the issue is now resolved by:
```"when",(when|int|string())```

So the `when` is now a timestamp, like `1687033853.332966`, then the timestamp is converted to an integer, like `1687033853` and then finally converted to a string, like `"1687033853"`, to be added to the data.

On the Android you then see that the notification has either occurred now, in the future or in the past.
