### PR TITLE
Change notification message to a template selector

### DIFF
--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1031,7 +1031,7 @@ sequence:
               {#- https://companion.home-assistant.io/docs/notifications/critical-notifications#android-text-to-speech-alarm-stream-max-volume -#}
               {%- if (data_device_ring|lower)=="max" and (notify_message|upper)=="TTS" -%}
               {%- set ns.data=ns.data+[("media_stream","alarm_stream_max")] -%}
-              {%- set data_importance="max" -%}
+              {%- set data_importance="high" -%}
               {%- endif -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#notification-icon -#}

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -258,6 +258,16 @@ fields:
           - Fan
         custom_value: true
         multiple: false
+  data_channel_remove:
+    name: Android Only - Removing a Notification channel (Optional)
+    description: |-
+      If you wish to remove a channel. Depending on when you installed the app you may want to enable this option with the Notification channel (`data_channel`) `default` to clean up the old default channel
+      *WARNING* The Notification Message (`notify_message`) will be ignored/overwritten.
+    required: false
+    example: >-
+      True
+    selector:
+      boolean:
   data_tag:
     name: Notification tag (Optional)
     description: Replace an existing notification by using a tag for the notification. All subsequent notifications will take the place of a notification with the same tag.
@@ -1006,6 +1016,9 @@ sequence:
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#notification-channels -#}
               {%- if data_channel is defined -%}
               {%- set ns.data=ns.data+[("channel",data_channel)] -%}
+              {%- if data_channel_remove is defined and bool(data_channel_remove,false)==true -%}
+              {%- set notify_message="remove_channel" -%}
+              {%- endif -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#text-to-speech-notifications -#}
               {%- if notify_title is defined and (notify_message|upper)=="TTS" -%}

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -183,21 +183,21 @@ fields:
     required: false
     example: mdi:motion-outline
     selector:
-      icon: null
+      icon:
   data_notification_color:
     name: Android Only - Color of the notification icon (Optional)
     description: In Android you can set the color of the notification icon
     required: false
     example: "[255,0,0]"
     selector:
-      color_rgb: null
+      color_rgb:
   notify_title:
     name: Notification title (Optional)
     description: Notification title, required when used with TTS
     required: false
     example: Frontdoor
     selector:
-      template: null
+      template:
   data_subtitle:
     name: Notification Subtitle / subject (Optional)
     description: Subtitles and subjects are secondary headings
@@ -229,7 +229,7 @@ fields:
     example: >-
       true
     selector:
-      boolean: null
+      boolean:
   data_group:
     name: Notification grouping (Optional)
     description: Combine notification together visually.
@@ -322,7 +322,7 @@ fields:
     example: >-
       true
     selector:
-      boolean: null
+      boolean:
   data_persistent:
     name: Android Only - Persistent notification? (Optional)
     description: Persistent notifications are notifications that cannot be dismissed by swiping away. It requires the Notification tag to be set. If not set it will set it to persistent.

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -213,6 +213,7 @@ fields:
     required: true
     example: There is somebody at the door!
     selector:
+      template:
   notify_tts:
     name: Android Only - Notify using TTS
     description: |-
@@ -1023,7 +1024,7 @@ sequence:
             servicedata: >-
               {# object which stores all options -#}
               {%- set ns=namespace(servicedata=[],data=[],push=[],sound=[],actions=[],hex_color="#") -%}
-
+              
               {%- if notify_message is not defined -%}
               {%- set notify_message='The `notify_message` field was not defined. What have you forgotten this time 🙂?' -%}
               {%- endif -%}

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1073,8 +1073,11 @@ sequence:
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#replacing -#}
               {%- if data_tag is defined -%}
               {%- set ns.data=ns.data+[("tag",data_tag)] -%}
+              {%- endif -%}
               {%- if data_tag_clear_notification is defined and bool(data_tag_clear_notification,false)==true -%}
               {%- set notify_message="clear_notification" -%}
+              {%- if data_tag is not defined -%}
+              {%- set ns.data=ns.data+[("tag","persistent")] -%}
               {%- endif -%}
               {%- endif -%}
 

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1024,7 +1024,7 @@ sequence:
             servicedata: >-
               {# object which stores all options -#}
               {%- set ns=namespace(servicedata=[],data=[],push=[],sound=[],actions=[],hex_color="#") -%}
-              
+
               {%- if notify_message is not defined -%}
               {%- set notify_message='The `notify_message` field was not defined. What have you forgotten this time 🙂?' -%}
               {%- endif -%}
@@ -1042,8 +1042,9 @@ sequence:
               {%- endif -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#text-to-speech-notifications -#}
-              {%- if notify_tts is defined and bool(notify_tts,false)==true and notify_message is defined -%}
+              {%- if notify_tts is defined and bool(notify_tts,false)==true and notify_message is defined and notify_message is not in ['TTS','clear_notification','remove_channel'] -%}
               {%- set ns.data=ns.data+[("tts_text",notify_message)] -%}
+              {%- set notify_message="TTS"-%}
               {%- endif -%}
               {#- By default Text To Speech notifications use the music stream so they will bypass the ringer mode on the device as long as the device's volume is not set to 0. You have the option of using media_stream: alarm_stream to have your notification spoken regardless of music volume. -#}
               {%- if data_device_ring is defined and (data_device_ring|lower) in ["on","max"] -%}
@@ -1344,9 +1345,6 @@ sequence:
               {%- if notify_message is not defined -%}
               {%- set notify_message="Hello World" -%}
               {%- endif -%}
-              {%- if (notify_message|lower)=="clear_notification" -%}
-              {%- set notify_message=(notify_message|lower) -%}
-              {%- endif -%}
               {%- set ns.servicedata=ns.servicedata+[("message",notify_message)] -%}
               {%- set ns.servicedata=ns.servicedata+[("data",dict.from_keys(ns.data))] -%}
               {#- Finally show the results as an DICT -#}
@@ -1381,7 +1379,7 @@ sequence:
                 - variables:
                     notify_message_actions_text: !input notify_message_actions_text
                     servicedata: >-
-                      {%- if is_android_auto_active==true -%}
+                      {%- if is_android_auto_active==true and notify_message is defined and notify_message not in ['clear_notification','remove_channel']-%}
                       {#- If actions are defined then process each action title and add it to the notify_message -#}
                       {%- if servicedata['data'] is not defined -%}
                       {%- set servicedata=dict((servicedata),**({'data':{}})) -%}
@@ -1400,16 +1398,18 @@ sequence:
 
                       {#- Create a data dict with the previous servicedata['data'] information and add to the data the tts_text -#}
                       {#- The tts_text is what will be used for TTS -#}
+                      
+                      {%- if notify_message not in ['TTS','clear_notification','remove_channel'] -%}
                       {%- set servicedata=dict((servicedata),**({'data':dict(servicedata['data'],**{'tts_text':notify_message})})) -%}
-
                       {#- Create the whole servicedata dict with the previous data information and replace the message with the TTS value -#}
                       {%- set servicedata=dict((servicedata),**({'message':'TTS'})) -%}
+                      {%- endif -%}
 
                       {#- Finally remove the old title from the dict -#}
                       {%- set servicedata=dict.from_keys(servicedata.items()|rejectattr('0','in','title')|list)%}
                       {{servicedata}}
                       {%- else -%}
                       {%- set servicedata={'comment':'Android Auto is not active'} -%}
-                      {%- endif -%}
+                      {%- endif %}
                 - service: "{{service}}"
                   data: "{{servicedata}}"

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -8,11 +8,16 @@ blueprint:
   input:
     notify_message_actions_text:
       name: Android Only - Enter a custom Text to Speech text used to anounch the actions, when your device is connected to the Android Auto.
-      description: When you mobile device is connect to Android Auto then you can enable the 'Android Only - Notify using TTS whilst using Andriod Auto?'. And when you have actions defined then you can announce them by this introduction sentence. [The TTS current support is limited to the current Text To Speech locale set on the device](https://companion.home-assistant.io/docs/notifications/notifications-basic#text-to-speech-notifications).
+      description: |-
+        When you mobile device is connect to Android Auto then you can enable the 'Android Only - Notify using TTS whilst using Andriod Auto?'. 
+        And when you have actions defined then you can announce them by this introduction sentence. 
+        [The TTS current support is limited to the current Text To Speech locale set on the device](https://companion.home-assistant.io/docs/notifications/notifications-basic#text-to-speech-notifications).
+        Enter a custom value that matches your need.
       default: Select one of the following actions on your phone
       selector:
         select:
           options:
+            - Enter an custom value
             - Select 1 of the following actions on your phone
             - Selecteer 1 van de volgende acties op je telefoon
           custom_value: true
@@ -167,6 +172,12 @@ fields:
         multiple: true
   notify_home_or_away:
     name: Notify those that are Home or Away?
+    description: |-
+      With this option you can filter the devices based on their location. 
+      • Select `Home` when you only want to notify those (`notify_devices`) devices that are in the zone Home.
+      • Select `Away` when you only want to notify those (`notify_devices`) devices that are NOT in the zone Home.
+      • Select `Both` when it does not matter where those (`notify_devices`) devices are, they will be notified. 
+      If not specified, then `Both` will be used.
     required: false
     example: Both
     selector:
@@ -179,7 +190,7 @@ fields:
           - Both
   data_notification_icon:
     name: Android Only - Notification icon (Optional)
-    description: Changing the default notification status bar icon
+    description: Change the default notification status bar icon to an mdi icon
     required: false
     example: mdi:motion-outline
     selector:
@@ -235,12 +246,13 @@ fields:
       boolean:
   data_group:
     name: Notification grouping (Optional)
-    description: Combine notification together visually.
+    description: Combine notification together visually. Custom values are allowed.
     required: false
     example: Motion
     selector:
       select:
         options:
+          - Enter an custom value
           - Alarm
           - Example
           - Motion
@@ -252,11 +264,13 @@ fields:
       Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features.
       Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations.
       Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
+      Custom values are allowed.
     required: false
     example: Motion
     selector:
       select:
         options:
+          - Enter an custom value
           - Motion Detected
           - default
           - Importance
@@ -283,12 +297,13 @@ fields:
       boolean:
   data_tag:
     name: Notification tag (Optional)
-    description: Replace an existing notification by using a tag for the notification. All subsequent notifications will take the place of a notification with the same tag.
+    description: Replace an existing notification by using a tag for the notification. All subsequent notifications will take the place of a notification with the same tag. Custom values are allowed.
     required: false
     example: backyard-motion-detected
     selector:
       select:
         options:
+          - Enter an custom value
           - backyard-motion-detected
           - alarm
           - doorbell
@@ -356,7 +371,7 @@ fields:
     example: >-
       true
     selector:
-      boolean: null
+      boolean:
   data_timeout:
     name: Android Only - Timeout message in seconds (Optional)
     description: How many seconds a notification will be shown on a users device before being removed/dismissed automatically.
@@ -375,7 +390,7 @@ fields:
     description: Shows a timestamp. Notification will not disappear when the timer reaches 0. Instead, it will continue decrementing into negative values.
     required: false
     selector:
-      datetime: null
+      datetime:
   data_chronometer_enable:
     name: Android Only - (when combined with data_chronometer) Enable the Notifications timer with a count up/down timer (Optional)
     description: Show a count up/down timer. Notification will not disappear when the timer reaches 0. Instead, it will continue decrementing into negative values.
@@ -383,7 +398,7 @@ fields:
     example: >-
       true
     selector:
-      boolean: null
+      boolean:
   data_critical:
     name: iOS Only - Critical notification? (Optional)
     description: Critical alerts always appear at the top of your lock screen above all other notifications, and play a sound even if Do Not Disturb is enabled or the iPhone is muted.
@@ -391,7 +406,7 @@ fields:
     example: >-
       true
     selector:
-      boolean: null
+      boolean:
   data_ios_sound:
     name: iOS Only - Sounds? (Optional)
     description:
@@ -399,12 +414,14 @@ fields:
       For more information click [here](https://companion.home-assistant.io/docs/notifications/notification-sounds#custom-push-notification-sounds).
       Adding a custom sound to a notification allows you to easily identify the notification without even looking at your device.
       You must use the full filename (including extension) in the payload.
-      If "iOS Only - Sound Volume Level" is not defined, then it will set the default sound level to 50%
+      If "iOS Only - Sound Volume Level" is not defined, then it will set the default sound level to 50%.
+      Custom values are allowed, as long as they match the sound file.
     required: false
     example: US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav
     selector:
       select:
         options:
+          - Enter an custom value, see https://companion.home-assistant.io/docs/notifications/notification-sounds#custom-push-notification-sounds
           - default
           - 3rdParty_DirectionDown_Haptic.caf
           - 3rdParty_DirectionUp_Haptic.caf
@@ -871,8 +888,8 @@ fields:
     selector:
       select:
         options:
-          - /lovelace/
           - Enter an custom value
+          - /lovelace/
           - "app://com.twitter.android"
           - "settings://notification_history"
           - "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end"

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -167,7 +167,7 @@ fields:
         multiple: true
   notify_home_or_away:
     name: Notify those that are Home or Away?
-    required: true
+    required: false
     example: Both
     selector:
       select:

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -62,8 +62,8 @@ blueprint:
     data:
       notify_home_or_away: Both
       data_tag: Use this tag when you need to remove it
+      data_tag_clear_notification: true
       data_importance: high
-      notify_message: clear_notification
     ```
     ### Example 3 ###
     Send a notification with camera image file. The data_camera can accept various
@@ -193,9 +193,9 @@ fields:
       color_rgb:
   notify_title:
     name: Notification title (Optional)
-    description: Notification title, required when used with TTS
+    description: Notification title
     required: false
-    example: Frontdoor
+    example: Motion • Frontdoor
     selector:
       template:
   data_subtitle:
@@ -300,7 +300,9 @@ fields:
         multiple: false
   data_tag_clear_notification:
     name: Remove Notifications
-    description: To remove the persistent notification(s) we send clear_notification to the tag (`data_tag`) that we defined. *WARNING* The Notification Message (`notify_message`) will be ignored/overwritten.
+    description: |-
+      Removes the notification(s) with a certain tag (see `data_tag`). 
+      To remove/clear the persistent notification(s): Use `data_tag: persistant`. *WARNING* The Notification Message (`notify_message`) will be ignored/overwritten.
     required: false
     example: >-
       True

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -213,6 +213,15 @@ fields:
     required: true
     example: There is somebody at the door!
     selector:
+  notify_tts:
+    name: Android Only - Notify using TTS
+    description: |-
+      Get your (Andriod) device to speak the notification.
+      Use the notification message (`notify_message`), required when used with TTS.
+      **NOTE** The Notification title (`notify_title`) will be ignored
+    required: false
+    selector:
+      boolean:
   notify_tts_in_car:
     name: Android Only - Notify using TTS whilst using Andriod Auto? (Optional)
     description: |-
@@ -1024,21 +1033,21 @@ sequence:
               {%- endif -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#text-to-speech-notifications -#}
-              {%- if notify_title is defined and (notify_message|upper)=="TTS" -%}
-              {%- set ns.data=ns.data+[("tts_text",notify_title)] -%}
+              {%- if notify_tts is defined and bool(notify_tts,false)==true and notify_message is defined -%}
+              {%- set ns.data=ns.data+[("tts_text",notify_message)] -%}
               {%- endif -%}
               {#- By default Text To Speech notifications use the music stream so they will bypass the ringer mode on the device as long as the device's volume is not set to 0. You have the option of using media_stream: alarm_stream to have your notification spoken regardless of music volume. -#}
               {%- if data_device_ring is defined and (data_device_ring|lower) in ["on","max"] -%}
               {%- set data_importance="high" -%}
               {#- https://companion.home-assistant.io/docs/notifications/critical-notifications#android-text-to-speech-alarm-stream -#}
-              {%- if (data_device_ring|lower)=="on" and (notify_message|upper)=="TTS" -%}
+              {%- if (data_device_ring|lower)=="on" and bool(notify_tts,false)==true -%}
               {%- set ns.data=ns.data+[("media_stream","alarm_stream")] -%}
               {%- endif -%}
-              {%- if (data_device_ring|lower)=="on" and (notify_message|upper)!="TTS" -%}
+              {%- if (data_device_ring|lower)=="on" and bool(notify_tts,false)!=true -%}
               {%- set ns.data=ns.data+[("channel","alarm_stream")] -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/critical-notifications#android-text-to-speech-alarm-stream-max-volume -#}
-              {%- if (data_device_ring|lower)=="max" and (notify_message|upper)=="TTS" -%}
+              {%- if (data_device_ring|lower)=="max" and bool(notify_tts,false)==true -%}
               {%- set ns.data=ns.data+[("media_stream","alarm_stream_max")] -%}
               {%- set data_importance="high" -%}
               {%- endif -%}
@@ -1313,15 +1322,12 @@ sequence:
               {%- set ns.data=ns.data+[("push",dict.from_keys(ns.push))] -%}
               {%- endif -%}
               {#- message and title are basic entries, but title is optional -#}
-              {%- if notify_title is defined and (notify_message|upper)!="TTS" -%}
+              {%- if notify_title is defined and (notify_tts is not defined or (notify_tts is defined and bool(notify_tts,false)==false)) -%}
               {%- set ns.servicedata=ns.servicedata+[("title",notify_title)] -%}
               {%- endif -%}
               {#- make sure that the message: <value> has an default value or is formatted correctly -#}
               {%- if notify_message is not defined -%}
               {%- set notify_message="Hello World" -%}
-              {%- endif -%}
-              {%- if (notify_message|upper)=="TTS" -%}
-              {%- set notify_message="TTS" -%}
               {%- endif -%}
               {%- if (notify_message|lower)=="clear_notification" -%}
               {%- set notify_message=(notify_message|lower) -%}

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -297,6 +297,14 @@ fields:
           - fan
         custom_value: true
         multiple: false
+  data_tag_clear_notification:
+    name: Remove Notifications
+    description: To remove the persistent notification(s) we send clear_notification to the tag (`data_tag`) that we defined. *WARNING* The Notification Message (`notify_message`) will be ignored/overwritten.
+    required: false
+    example: >-
+      True
+    selector:
+      boolean:
   data_importance:
     name: Important notification
     description: Notifications will appear immediately in most cases. However, in some cases (such as phone being stationary or when screen has been turned off for prolonged period of time) and this is to override that default behavior
@@ -1064,6 +1072,9 @@ sequence:
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#replacing -#}
               {%- if data_tag is defined -%}
               {%- set ns.data=ns.data+[("tag",data_tag)] -%}
+              {%- if data_tag_clear_notification is defined and bool(data_tag_clear_notification,false)==true -%}
+              {%- set notify_message="clear_notification" -%}
+              {%- endif -%}
               {%- endif -%}
 
               {%- if manufacturer!="Apple" and data_persistent is defined -%}

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: Notify Mobile App Devices
+  name: Notify Mobile App Devices (2024.2)
   domain: script
   homeassistant:
     min_version: 2023.6.0
@@ -23,6 +23,9 @@ blueprint:
           custom_value: true
           multiple: false
   description: |-
+    **Version: 2024.2**
+
+    ## Info ##
     **Struggling to make use of the notification options of the [Home Assistant Companion App](https://companion.home-assistant.io/) on your mobile device?**
     **Then this script can help you in the right direction.**
     ***

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -213,18 +213,11 @@ fields:
     required: true
     example: There is somebody at the door!
     selector:
-      select:
-        options:
-          - TTS
-          - remove_channel
-          - clear_notification
-          - There is somebody at the door!
-          - There is somebody in the garden!
-        custom_value: true
-        multiple: false
-  notify_in_car_using_tts:
+  notify_tts_in_car:
     name: Android Only - Notify using TTS whilst using Andriod Auto? (Optional)
-    description: Upgrade the notification message to a TTS message, when the `binary_sensor.###_android_auto` is `on`. This can be useful whilst driving with Android Auto that the notification that you are sending is announched via TTS.
+    description: |-
+      Upgrade the notification message to a TTS message, when the `binary_sensor.###_android_auto` is `on`.
+      This can be useful whilst driving with Android Auto that the notification that you are sending is announched via TTS.
     required: false
     example: >-
       true
@@ -1332,23 +1325,28 @@ sequence:
             - conditions:
                 - condition: template
                   value_template: >-
-                    {{manufacturer != "Apple" and 
+                    {%- set is_android_auto_active=(
+                    manufacturer != "Apple" and 
                     entities is defined and 
                     (entities|select('search','_android_auto')|list|count==1) and 
                     (states((entities|select("search","_android_auto")|list)[0])=="on") and 
-                    notify_in_car_using_tts is defined and 
-                    bool(notify_in_car_using_tts,false)==true and 
-                    notify_message is defined and 
-                    notify_message!='TTS'}}
+                    notify_tts_in_car is defined and 
+                    bool(notify_tts_in_car,false)==true and 
+                    (
+                    (notify_message is defined and notify_message!='TTS') 
+                    or 
+                    (notify_title is defined and notify_tts is defined and bool(notify_tts,false)==true)
+                    )) -%}
+                    {{is_android_auto_active}}
               sequence:
                 - variables:
                     notify_message_actions_text: !input notify_message_actions_text
                     servicedata: >-
+                      {%- if is_android_auto_active==true -%}
                       {#- If actions are defined then process each action title and add it to the notify_message -#}
-                      {% if servicedata['data'] is not defined %}
+                      {%- if servicedata['data'] is not defined -%}
                       {%- set servicedata=dict((servicedata),**({'data':{}})) -%}
-                      {%endif%}
-
+                      {%- endif -%}
                       {%- if servicedata['data'] is defined and servicedata['data']['actions'] is defined -%}
                       {%- set ns=namespace(actions=[]) -%}
                       {%- for action in servicedata['data']['actions'] -%}
@@ -1371,5 +1369,8 @@ sequence:
                       {#- Finally remove the old title from the dict -#}
                       {%- set servicedata=dict.from_keys(servicedata.items()|rejectattr('0','in','title')|list)%}
                       {{servicedata}}
+                      {%- else -%}
+                      {%- set servicedata={'comment':'Android Auto is not active'} -%}
+                      {%- endif -%}
                 - service: "{{service}}"
                   data: "{{servicedata}}"

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -238,7 +238,10 @@ fields:
         multiple: false
   data_channel:
     name: Android Only - Notification channel (Optional)
-    description: Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features.Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations. Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
+    description: |-
+      Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features.
+      Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations.
+      Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
     required: false
     example: Motion
     selector:
@@ -1053,9 +1056,11 @@ sequence:
               {%- if data_tag is defined -%}
               {%- set ns.data=ns.data+[("tag",data_tag)] -%}
               {%- endif -%}
+
               {%- if manufacturer!="Apple" and data_persistent is defined -%}
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#persistent-notification -#}
               {#- making sure that an boolean is specified, otherwise skipping -#}
+
               {%- if data_persistent is boolean -%}
               {%- set data_persistent=bool(data_persistent,false) -%}
               {%- set ns.data=ns.data+[("persistent",data_persistent)] -%}
@@ -1158,7 +1163,7 @@ sequence:
               {%- set ns.data=ns.data+[("timeout",(data_timeout|int))] -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic#sticky-notification -#}
-              {%- if data_sticky is defined and data_sticky|lower in [true,false,"true","false",0,1,"0","1","yes","no","enable","disable"] -%}
+              {%- if data_sticky is defined and bool(data_sticky,false)==true -%}
               {%- set ns.data=ns.data+[("sticky",bool(data_sticky,false))] -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/notification-attachments -#}

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1061,7 +1061,7 @@ sequence:
               {%- endif -%}
               {%- endif -%}
               {#- https://companion.home-assistant.io/docs/notifications/notifications-basic/#text-to-speech-notifications -#}
-              {%- if notify_tts is defined and bool(notify_tts,false)==true and notify_message is defined and notify_message is not in ['TTS','clear_notification','remove_channel'] -%}
+              {%- if manufacturer!="Apple" and notify_tts is defined and bool(notify_tts,false)==true and notify_message is defined and notify_message is not in ['TTS','clear_notification','remove_channel'] -%}
               {%- set ns.data=ns.data+[("tts_text",notify_message)] -%}
               {%- set notify_message="TTS"-%}
               {%- endif -%}
@@ -1372,30 +1372,40 @@ sequence:
               {#- Finally show the results as an DICT -#}
               {%- set servicedata=dict.from_keys(ns.servicedata) -%}
               {{- servicedata }}
+        - variables:
+            notify_condition: >-
+              {%- set notify_condition=not (manufacturer=="Apple" and (notify_tts is defined and bool(notify_tts,false)==true) and data_ios_sound is not defined) -%}
+              {{notify_condition}}
         - choose:
             - conditions:
                 - condition: template
                   value_template: >-
-                    {{not (manufacturer=="Apple" and notify_title is defined and (notify_message|upper)=="TTS" and data_ios_sound is not defined)}}
+                    {{notify_condition}}
               sequence:
                 - service: "{{service}}"
-                  data: "{{servicedata}}"
+                  data: >-
+                    {%- if notify_condition==true -%}
+                    {{servicedata}}
+                    {%- endif %}
+        - variables:
+            is_android_auto_active: >-
+              {%- set is_android_auto_active=(
+              manufacturer != "Apple" and 
+              entities is defined and 
+              (entities|select('search','_android_auto')|list|count==1) and 
+              (states((entities|select("search","_android_auto")|list)[0])=="on") and 
+              notify_tts_in_car is defined and 
+              bool(notify_tts_in_car,false)==true and 
+              (
+              (notify_message is defined and notify_message!='TTS') 
+              or 
+              (notify_title is defined and notify_tts is defined and bool(notify_tts,false)==true)
+              )) -%}
+              {{is_android_auto_active}}
         - choose:
             - conditions:
                 - condition: template
                   value_template: >-
-                    {%- set is_android_auto_active=(
-                    manufacturer != "Apple" and 
-                    entities is defined and 
-                    (entities|select('search','_android_auto')|list|count==1) and 
-                    (states((entities|select("search","_android_auto")|list)[0])=="on") and 
-                    notify_tts_in_car is defined and 
-                    bool(notify_tts_in_car,false)==true and 
-                    (
-                    (notify_message is defined and notify_message!='TTS') 
-                    or 
-                    (notify_title is defined and notify_tts is defined and bool(notify_tts,false)==true)
-                    )) -%}
                     {{is_android_auto_active}}
               sequence:
                 - variables:
@@ -1431,7 +1441,11 @@ sequence:
                       {%- set servicedata=dict.from_keys(servicedata.items()|rejectattr('0','in','title')|list)%}
                       {{servicedata}}
                       {%- else -%}
+                      {%- if manufacturer == "Apple"  -%}
+                      {%- set servicedata={'comment':'TTS is not supported on Apple Car Play'} -%}
+                      {%- else -%}
                       {%- set servicedata={'comment':'Android Auto is not active'} -%}
+                      {%- endif -%}
                       {%- endif %}
                 - service: "{{service}}"
                   data: "{{servicedata}}"

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1345,6 +1345,9 @@ sequence:
               {%- if notify_message is not defined -%}
               {%- set notify_message="Hello World" -%}
               {%- endif -%}
+              {%- if (notify_message|lower)=="clear_notification" -%}
+              {%- set notify_message=(notify_message|lower) -%}
+              {%- endif -%}
               {%- set ns.servicedata=ns.servicedata+[("message",notify_message)] -%}
               {%- set ns.servicedata=ns.servicedata+[("data",dict.from_keys(ns.data))] -%}
               {#- Finally show the results as an DICT -#}
@@ -1398,7 +1401,7 @@ sequence:
 
                       {#- Create a data dict with the previous servicedata['data'] information and add to the data the tts_text -#}
                       {#- The tts_text is what will be used for TTS -#}
-                      
+
                       {%- if notify_message not in ['TTS','clear_notification','remove_channel'] -%}
                       {%- set servicedata=dict((servicedata),**({'data':dict(servicedata['data'],**{'tts_text':notify_message})})) -%}
                       {#- Create the whole servicedata dict with the previous data information and replace the message with the TTS value -#}


### PR DESCRIPTION
**This version packs various fixes, breaking changes, and updates to the documentation/descriptions of the various selectors.**

### Breaking changes

#### Android Auto option
The Android Auto option was using TTS but TTS could also be send to an Android Phone using `notify_tts`. Thus to be consistent the option was updated from `notify_in_car_using_tts` into `notify_tts_in_car` . 

  OLD: `notify_in_car_using_tts: true`
  NEW: `notify_tts_in_car: true`

#### Clear notification
To clear notification you would have to know the `notify_message: clear_notification` with the `data_tag` combination. Now that has been simplified to `data_tag_clear_notification: true` with the `data_tag` combination, as it makes it more consistent with the other options.

  OLD: `notify_message: clear_notification`
  NEW: `data_tag_clear_notification: true`

### New options
New options that have been introduced:
- [x] `data_channel_remove`
- [x] `notify_tts`

#### Removing a Notification channel
   `data_channel_remove` has been introduced. This option is used in conjunction with `data_channel` will remove a channel. As an example:
_The following example will create the ` A custom channel` -channel so you can tailor its notification behaviour._
```
service: script.notify_devices
data:
  data_channel: An custom channel
  notify_message: "Send messages to a custom channel, so you can tailor its notification behaviour."
```
_The following example will remove the `An custom channel` -channel._
```
service: script.notify_devices
data:
  data_channel: An custom channel
  data_channel_remove: true
  notify_message: "With \"data_channel_remove: true\" and \"data_channel: \" you can remove the custom channel."
```
_The following example will remove the default `default ` -channel._
```
service: script.notify_devices
data:
  data_channel: default 
  data_channel_remove: true
  notify_message: "With \"data_channel_remove: true\" you can remove the default channel."
```
#### Android Only - Notify using TTS
Get your (Andriod) device to speak the notification. Use the **Notification message** (`notify_message`) as the message, required when used with TTS. 
**NOTE** The Notification title (`notify_title`) will be ignored

_The following example will send an TTS message to all Android devices_
```
service: script.notify_devices
data:
  notify_message: "This message is spoken via TTS only on Android devices. If you hear it on your phone, then it is supported 👯"
  notify_tts: true
```
### Incorporated issues
In this version the `Notification message` has changed into an `template` option. For more information see https://github.com/Grumblezz/Home-Assistant-Notify-Mobile-Companion-App-Devices/issues/10#issue-2094685240

### Other updates
In this version the `notify_home_or_away` is not required anymore. The default now is `Both` when it is not set. See https://community.home-assistant.io/t/notify-mobile-companion-app-devices/512487/10?u=grumblezz 