### PR TITLE
Cant notify all devices if any companion app doesnt support notifications

### DIFF
--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1496,6 +1496,7 @@ sequence:
                     {{notify_condition}}
               sequence:
                 - action: "{{service}}"
+                  continue_on_error: true
                   data: >-
                     {%- if notify_condition==true -%}
                     {{servicedata}}
@@ -1562,4 +1563,5 @@ sequence:
                       {%- endif %}
                       {{servicedata}}
                 - action: "{{service}}"
+                  continue_on_error: true
                   data: "{{servicedata}}"

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -173,6 +173,15 @@ fields:
         filter:
           - integration: mobile_app
         multiple: true
+  exclude_notify_devices:
+    name: Exclude Device to notify
+    description: Device needs to run the official Home Assistant app to receive notifications. If not specified, then all devices are used.
+    required: false
+    selector:
+      device:
+        filter:
+          - integration: mobile_app
+        multiple: true
   notify_home_or_away:
     name: Notify those that are Home or Away?
     description: |-
@@ -948,6 +957,10 @@ sequence:
         {%- set ns_devices.device_id=ns_devices.device_id+[device_id(e)] -%}
         {%- endfor -%}
         {%- set all_devices=ns_devices.device_id -%}
+        {%- endif %}
+        {%- if exclude_notify_devices is defined -%}
+        {#- If the user uses the field "exclude_notify_devices" then exclude that/those device(s) -#}
+        {%- set all_devices=all_devices|reject('in',exclude_notify_devices)|list -%}
         {%- endif %}
         {{all_devices}}
       notify_devices_home: >-

--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -1,8 +1,8 @@
 blueprint:
-  name: Notify Mobile App Devices (2024.08)
+  name: Notify Mobile App Devices (2024.12)
   domain: script
   homeassistant:
-    min_version: 2024.8.0
+    min_version: 2024.10.0
   source_url: https://github.com/Grumblezz/Home-Assistant-Notify-Mobile-Companion-App-Devices/blob/main/notify_devices.yaml
   author: Grumblezz
   input:
@@ -23,7 +23,7 @@ blueprint:
           custom_value: true
           multiple: false
   description: |-
-    **Version: 2024.08**
+    **Version: 2024.12**
 
     ## Info ##
     **Struggling to make use of the notification options of the [Home Assistant Companion App](https://companion.home-assistant.io/) on your mobile device?**


### PR DESCRIPTION
This fixes the issues for #14 

Introduced a new parameter `exclude_notify_devices`:
[Added a new parameter exclude_notify_devices to exclude devices fro…](https://github.com/Grumblezz/Home-Assistant-Notify-Mobile-Companion-App-Devices/commit/a9bff7731bc5d1f5b133ba9d2a6c74d7ec0ec81b)

And an improvement to continue when the `notify` service results in an error:
[Included the continue_on_error: true to continue when an error occurs, instead of stopping the whole script](https://github.com/Grumblezz/Home-Assistant-Notify-Mobile-Companion-App-Devices/commit/72f3b8713d4eebbc513f8ef394295e8da0a755ea)