### PR TITLE
Feature: Only include devices that are in the specified zone(s).

### DIFF
--- a/notify_devices.yaml
+++ b/notify_devices.yaml
@@ -173,6 +173,15 @@ fields:
         filter:
           - integration: mobile_app
         multiple: true
+  filter_zones:
+    name: Device(s) to notify in a zone
+    description: Only include devices that are in the specified zone(s). The device needs to run the official Home Assistant app to receive notifications. If not specified, then all devices are used.
+    selector:
+      entity:
+        multiple: true
+        filter:
+          domain: zone
+    required: false
   exclude_notify_devices:
     name: Exclude Device to notify
     description: Device needs to run the official Home Assistant app to receive notifications. If not specified, then all devices are used.


### PR DESCRIPTION
New features which allows you to notify only those devices in a specific zone for example, Home and Office: 
![image](https://github.com/user-attachments/assets/0f4734e0-7c09-43ff-96a2-372ea65c8546)
